### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## ['3.0.0'] - 2022-09-26
+* Enhancements:
+* Changes:
+  * Default default commands to :help.
+  * Remove references to system for options, folder locations, etc. These were not being used and the nature of this tool is that global options should suffice.
+* Bug Fixes: Not really a branch-name bug, but patched Thor bug that displays nested subcommands incorrectly.
+
 ## ['2.2.0'] - 2022-09-24
 * Enhancements:
-  * Add support for `branch-name create` `-x` argument (see `branch-name help create`) which allows you to position the ticket and ticket description within the forulated branch name.
+  * Add support for `branch-name create` `-x` argument (see `branch-name help create`) which allows you to position the ticket and ticket description within the formulated branch name.
   * The `branch-name create :project_location` option string now accepts any [`Time.strftime`](`https://apidock.com/ruby/Time/strftime`) format directive.
   * Add better test coverage, although not what it should be (I'm working on it); this started a "quick and dirty" tool.
   * `branch-name create` will now create the PROJECT_LOCATION if it does not exist.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    branch-name (2.2.0)
+    branch-name (3.0.0)
       activesupport (~> 7.0, >= 7.0.4)
       colorize (~> 0.8.1)
       os (~> 1.1, >= 1.1.4)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # `branch-name`
 
+[![GitHub version](http://badge.fury.io/gh/gangelo%2Fbranch-name.svg)](https://badge.fury.io/gh/gangelo%2Fbranch-name)
+
+[![Gem Version](https://badge.fury.io/rb/branch-name.svg)](https://badge.fury.io/rb/branch-name)
+
+[![](http://ruby-gem-downloads-badge.herokuapp.com/branch-name?type=total)](http://www.rubydoc.info/gems/branch-name/)
+[![Documentation](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](http://www.rubydoc.info/gems/branch-name/)
+
+[![Report Issues](https://img.shields.io/badge/report-issues-red.svg)](https://github.com/gangelo/branch-name/issues)
+
+[![License](http://img.shields.io/badge/license-MIT-yellowgreen.svg)](#license)
+
 `branch-name` is a gem that provides a command-line interface that allows you to accomplish several tasks, tasks I *personally* find myself having to carry out every time I work on a feature branch. I created this gem *for myself*; however, you are free to use it yourself, if any of these tasks fits into your personal routine:
 
 1. Formulate a git *feature branch name*, given a [jira](https://www.atlassian.com/software/jira) ticket and jira ticket description. **Why? Because I am constantly having to create git feature branch names that are based on jira ticket and jira ticket descriptions.**

--- a/lib/branch/name/cli.rb
+++ b/lib/branch/name/cli.rb
@@ -12,6 +12,7 @@ require_relative 'locatable'
 require_relative 'normalizable'
 require_relative 'projectable'
 require_relative 'subcommands/config'
+require_relative 'task_defaultable'
 require_relative 'version'
 
 module Branch
@@ -26,11 +27,11 @@ module Branch
       include Locatable
       include Normalizable
       include Projectable
+      include TaskDefaultable
 
       class_option :debug, type: :boolean, default: false
       class_option :verbose, type: :boolean, default: false
 
-      default_task :create
       map %w[--version -v] => :version
 
       desc 'create [OPTIONS] DESCRIPTION [TICKET]', 'Formulate a branch name based on a ticket

--- a/lib/branch/name/configurable.rb
+++ b/lib/branch/name/configurable.rb
@@ -34,20 +34,12 @@ module Branch
         File.join(local_folder, CONFIG_FILENAME)
       end
 
-      def system_config_file
-        File.join(system_folder, CONFIG_FILENAME)
-      end
-
       def global_config_file?
         File.exist? global_config_file
       end
 
       def local_config_file?
         File.exist? local_config_file
-      end
-
-      def system_config_file?
-        File.exist? system_config_file
       end
 
       def create_global_config_file!
@@ -58,20 +50,12 @@ module Branch
         create_config_file local_config_file
       end
 
-      def create_system_config_file!
-        create_config_file system_config_file
-      end
-
       def delete_global_config_file!
         delete_config_file global_config_file
       end
 
       def delete_local_config_file!
         delete_config_file local_config_file
-      end
-
-      def delete_system_config_file!
-        delete_config_file system_config_file
       end
 
       private

--- a/lib/branch/name/loadable.rb
+++ b/lib/branch/name/loadable.rb
@@ -12,7 +12,6 @@ module Branch
       def load_options(defaults: {})
         options = {}
 
-        options.merge!(load_config(system_config_file))
         options.merge!(load_config(global_config_file))
         options.merge!(load_config(local_config_file))
 

--- a/lib/branch/name/locatable.rb
+++ b/lib/branch/name/locatable.rb
@@ -19,25 +19,10 @@ module Branch
         Dir.pwd
       end
 
-      def system_folder
-        system_folder = Pathname.new('/')
-        unless system_folder.exist? && system_folder.directory?
-          puts "WARNING: system folder #{system_folder} does not exist, " \
-               "using global folder instead (#{global_folder})".red
-
-          return global_folder
-        end
-        system_folder.to_s
-      end
-
       def project_folder(options: {})
         return home_folder if options.blank?
 
         home_folder
-      end
-
-      def system_folder_equals_global_folder?
-        syetem_folder == global_folder
       end
 
       def temp_folder

--- a/lib/branch/name/subcommands/config.rb
+++ b/lib/branch/name/subcommands/config.rb
@@ -3,6 +3,7 @@
 require 'thor'
 require_relative '../configurable'
 require_relative '../exitable'
+require_relative 'delete'
 require_relative 'init'
 
 module Branch
@@ -44,38 +45,11 @@ module Branch
           end
         end
 
-        desc 'delete [OPTION]', 'Removes .branch-name file(s)'
-        long_desc <<-LONG_DESC
-          NAME
-          \x5
-          `branch-name config delete [OPTION]` -- will remove one or all .branch-name file(s)
-          depending on the OPTION.
-
-          SYNOPSIS
-          \x5
-          branch-name config delete [-a|-g|-l|-s]
-        LONG_DESC
-        method_option :all, type: :boolean, aliases: '-a'
-        method_option :global, type: :boolean, aliases: '-g'
-        method_option :local, type: :boolean, aliases: '-l'
-        method_option :system, type: :boolean, aliases: '-s'
-
-        def delete
-          if options[:all]
-            delete_global_config_file!
-            delete_local_config_file!
-            delete_system_config_file!
-          elsif options[:global]
-            delete_global_config_file!
-          elsif options[:local]
-            delete_local_config_file!
-          elsif options[:system]
-            delete_system_config_file!
-          end
-        end
-
         desc 'init SUBCOMMAND', 'Sets up config files for this gem'
         subcommand :init, Branch::Name::Subcommands::Init
+
+        desc 'delete SUBCOMMAND', 'Deletes one of all config files for this gem'
+        subcommand :delete, Branch::Name::Subcommands::Delete
       end
     end
   end

--- a/lib/branch/name/subcommands/config.rb
+++ b/lib/branch/name/subcommands/config.rb
@@ -5,6 +5,7 @@ require_relative '../configurable'
 require_relative '../exitable'
 require_relative 'delete'
 require_relative 'init'
+require_relative '../task_defaultable'
 
 module Branch
   module Name
@@ -12,8 +13,7 @@ module Branch
       class Config < ::Thor
         include Configurable
         include Exitable
-
-        default_task :info
+        include TaskDefaultable
 
         desc 'info', 'Displays information about this gem configuration'
         long_desc <<-LONG_DESC
@@ -36,12 +36,6 @@ module Branch
             say "Local config file exists: \"#{local_config_file}\"", :green
           else
             say "Local config file does not exist at: \"#{local_folder}\"", :yellow
-          end
-
-          if system_config_file?
-            say "System config file exists: \"#{system_config_file}\"", :green
-          else
-            say "System config file does not exist at: \"#{system_folder}\"", :yellow
           end
         end
 

--- a/lib/branch/name/subcommands/delete.rb
+++ b/lib/branch/name/subcommands/delete.rb
@@ -4,6 +4,7 @@ require 'thor'
 require_relative '../configurable'
 require_relative '../exitable'
 require_relative 'nestable'
+require_relative '../task_defaultable'
 
 module Branch
   module Name
@@ -12,23 +13,16 @@ module Branch
         include Configurable
         include Exitable
         include Nestable
+        include TaskDefaultable
 
         class << self
           def ascestor_name
             'config delete'
           end
-
-          def subcommand_help_map
-            {
-              all: "#{ascestor_name} all",
-              global: "#{ascestor_name} global",
-              help: "#{ascestor_name} help [SUBCOMMAND]",
-              local: "#{ascestor_name} local",
-            }
-          end
         end
 
         desc 'all', 'Deletes all config files (local and global) for this gem'
+        subcommand_help_override "#{ascestor_name} all"
         long_desc <<-LONG_DESC
           NAME
           \x5
@@ -46,6 +40,7 @@ module Branch
         end
 
         desc 'global', 'Deletes the global config file for this gem'
+        subcommand_help_override "#{ascestor_name} global"
         long_desc <<-LONG_DESC
           NAME
           \x5
@@ -62,6 +57,7 @@ module Branch
         end
 
         desc 'local', 'Deletes the local config file for this gem'
+        subcommand_help_override "#{ascestor_name} local"
         long_desc <<-LONG_DESC
           NAME
           \x5

--- a/lib/branch/name/subcommands/delete.rb
+++ b/lib/branch/name/subcommands/delete.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'thor'
+require_relative '../configurable'
+require_relative '../exitable'
+require_relative 'nestable'
+
+module Branch
+  module Name
+    module Subcommands
+      class Delete < ::Thor
+        include Configurable
+        include Exitable
+        include Nestable
+
+        class << self
+          def ascestor_name
+            'config delete'
+          end
+
+          def subcommand_help_map
+            {
+              all: "#{ascestor_name} all",
+              global: "#{ascestor_name} global",
+              help: "#{ascestor_name} help [SUBCOMMAND]",
+              local: "#{ascestor_name} local",
+            }
+          end
+        end
+
+        desc 'all', 'Deletes all config files (local and global) for this gem'
+        long_desc <<-LONG_DESC
+          NAME
+          \x5
+          `branch-name config delete all` -- will remove the all .branch-name config files.
+
+          SYNOPSIS
+          \x5
+          branch-name config delete all
+        LONG_DESC
+        method_option :all, type: :boolean, aliases: '-a'
+
+        def all
+          delete_global_config_file!
+          delete_local_config_file!
+        end
+
+        desc 'global', 'Deletes the global config file for this gem'
+        long_desc <<-LONG_DESC
+          NAME
+          \x5
+          `branch-name config delete global` -- will remove the global .branch-name config file.
+
+          SYNOPSIS
+          \x5
+          branch-name config delete global
+        LONG_DESC
+        method_option :global, type: :boolean, aliases: '-g'
+
+        def global
+          delete_global_config_file!
+        end
+
+        desc 'local', 'Deletes the local config file for this gem'
+        long_desc <<-LONG_DESC
+          NAME
+          \x5
+          `branch-name config delete local` -- will remove the local .branch-name config file.
+
+          SYNOPSIS
+          \x5
+          branch-name config delete local
+        LONG_DESC
+        method_option :local, type: :boolean, aliases: '-l'
+
+        def local
+          delete_local_config_file!
+        end
+      end
+    end
+  end
+end

--- a/lib/branch/name/subcommands/help_nestable.rb
+++ b/lib/branch/name/subcommands/help_nestable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Branch
+  module Name
+    module Subcommands
+      # This module helps fix a bug in Thor that prohibits help for nested
+      # subcommands from displaying help properly. Nested subcommands fail
+      # to display their subcommand ancestor command name. This fixes that
+      # bug. This module is used in conjunction with the Nestable module.
+      module HelpNestable
+        class << self
+          def included(base)
+            # Thor override
+            base.desc 'help [COMMAND]', 'Describe available commands or one specific command'
+            base.subcommand_help_override "config init help [SUBCOMMAND]"
+            def help(command = nil, subcommand = false)
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/branch/name/subcommands/init.rb
+++ b/lib/branch/name/subcommands/init.rb
@@ -4,33 +4,25 @@ require 'thor'
 require_relative '../configurable'
 require_relative '../exitable'
 require_relative 'nestable'
+require_relative '../task_defaultable'
 
 module Branch
   module Name
     module Subcommands
-      # https://www.atlassian.com/git/tutorials/setting-up-a-repository/git-config
       class Init < ::Thor
         include Configurable
         include Exitable
         include Nestable
+        include TaskDefaultable
 
         class << self
           def ascestor_name
             'config init'
           end
-
-          def subcommand_help_map
-            {
-              global: "#{ascestor_name} global",
-              help: "#{ascestor_name} help [SUBCOMMAND]",
-              local: "#{ascestor_name} local",
-            }
-          end
         end
 
-        default_task :global
-
         desc 'global', 'Creates and initializes a .branch-name file in the global folder'
+        subcommand_help_override "#{ascestor_name} global"
         long_desc <<-LONG_DESC
           NAME
           \x5
@@ -46,6 +38,7 @@ module Branch
         end
 
         desc 'local', 'Creates and initializes a .branch-name file in the local folder'
+        subcommand_help_override "#{ascestor_name} local"
         long_desc <<-LONG_DESC
           NAME
           \x5

--- a/lib/branch/name/subcommands/init.rb
+++ b/lib/branch/name/subcommands/init.rb
@@ -3,6 +3,7 @@
 require 'thor'
 require_relative '../configurable'
 require_relative '../exitable'
+require_relative 'nestable'
 
 module Branch
   module Name
@@ -11,6 +12,21 @@ module Branch
       class Init < ::Thor
         include Configurable
         include Exitable
+        include Nestable
+
+        class << self
+          def ascestor_name
+            'config init'
+          end
+
+          def subcommand_help_map
+            {
+              global: "#{ascestor_name} global",
+              help: "#{ascestor_name} help [SUBCOMMAND]",
+              local: "#{ascestor_name} local",
+            }
+          end
+        end
 
         default_task :global
 
@@ -18,12 +34,12 @@ module Branch
         long_desc <<-LONG_DESC
           NAME
           \x5
-          `branch-name init global` -- will create and initialize a .branch-name file
+          `branch-name config init global` -- will create and initialize a .branch-name file
           in the "#{Locatable.global_folder}" folder.
 
           SYNOPSIS
           \x5
-          branch-name init global
+          branch-name config init global
         LONG_DESC
         def global
           create_global_config_file!
@@ -33,32 +49,15 @@ module Branch
         long_desc <<-LONG_DESC
           NAME
           \x5
-          `branch-name init local` -- will create and initialize a .branch-name file
+          `branch-name config init local` -- will create and initialize a .branch-name file
           in the "#{Locatable.local_folder}" folder.
 
           SYNOPSIS
           \x5
-          branch-name init local
+          branch-name config init local
         LONG_DESC
         def local
           create_local_config_file!
-        end
-
-        desc 'system', 'Creates and initializes a .branch-name file in the system folder'
-        long_desc <<-LONG_DESC
-          NAME
-          \x5
-          `branch-name init system` -- will create and initialize a .branch-name file
-          in the "#{Locatable.system_folder}" folder.
-
-          SYNOPSIS
-          \x5
-          branch-name init system
-        LONG_DESC
-        def system
-          # create_system_config_file!
-          say_error 'System initialization is not available at this time', :red
-          exit 1
         end
       end
     end

--- a/lib/branch/name/subcommands/nestable.rb
+++ b/lib/branch/name/subcommands/nestable.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'help_nestable'
+
 module Branch
   module Name
     module Subcommands
@@ -11,21 +13,29 @@ module Branch
         class << self
           def included(base)
             base.extend ClassMethods
+            base.include HelpNestable
           end
         end
 
         module ClassMethods
-          def subcommand_help_map
+          def ascestor_name
             raise NotImplementedError
           end
 
-          def banner(command, namespace = nil, subcommand = false)
-            command.formatted_usage(self, $thor_runner, subcommand).split("\n").map do |formatted_usage|
+          # Thor override
+          def banner(command, _namespace = nil, subcommand = false)
+            command.formatted_usage(self, $thor_runner, subcommand).split("\n").map do |_formatted_usage|
               command_name = command.name.to_sym
-              require 'pry-byebug'
-              #binding.pry
-              "#{basename} #{subcommand_help_map[command_name]}"
+              "#{basename} #{@subcommand_help_override[command.usage]}"
             end.join("\n")
+          end
+
+          def subcommand_help_override(help_string)
+            raise "Thor.desc must be called for \"#{help_string}\" " \
+              'prior to calling .subcommand_help_override' if @usage.blank?
+
+            @subcommand_help_override = {} unless defined? @subcommand_help_override
+            @subcommand_help_override[@usage] = help_string
           end
         end
       end

--- a/lib/branch/name/subcommands/nestable.rb
+++ b/lib/branch/name/subcommands/nestable.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Branch
+  module Name
+    module Subcommands
+      # This module fixes a bug in Thor that prohibits help for nested
+      # subcommands from displaying help properly. Nested subcommands fail
+      # to display their subcommand ancestor command name. This fixes that
+      # bug.
+      module Nestable
+        class << self
+          def included(base)
+            base.extend ClassMethods
+          end
+        end
+
+        module ClassMethods
+          def subcommand_help_map
+            raise NotImplementedError
+          end
+
+          def banner(command, namespace = nil, subcommand = false)
+            command.formatted_usage(self, $thor_runner, subcommand).split("\n").map do |formatted_usage|
+              command_name = command.name.to_sym
+              require 'pry-byebug'
+              #binding.pry
+              "#{basename} #{subcommand_help_map[command_name]}"
+            end.join("\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/branch/name/task_defaultable.rb
+++ b/lib/branch/name/task_defaultable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Branch
+  module Name
+    # Forces the default Thor task to be :help
+    module TaskDefaultable
+      class << self
+        def included(base)
+          base.default_command :help
+        end
+      end
+    end
+  end
+end

--- a/lib/branch/name/version.rb
+++ b/lib/branch/name/version.rb
@@ -3,6 +3,6 @@
 module Branch
   module Name
     # branch-name version
-    VERSION = '2.2.0'
+    VERSION = '3.0.0'
   end
 end


### PR DESCRIPTION
## ['3.0.0'] - 2022-09-26
* Changes:
  * Default default commands to :help.
  * Remove references to system for options, folder locations, etc. These were not being used and the nature of this tool is that global options should suffice.
* Bug Fixes: Not really a branch-name bug, but patched Thor bug that displays nested subcommands incorrectly.