### PR TITLE
Bug fixes and changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## ['3.5.1'] - 2022-10-05
+* Bug Fixes
+  * Fix bug that failed to remove underscore (_) characters in ticket and ticket descriptions from folder and branch name formulation.
+  * Fix bug that allowed unacceptable project folder token separators in the project folder name (-p option). The rule is now: for `branch-name create`, if the `options[:separator]` option (-s) is included in `Branch::Name::Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS`, `options[:separator]` (-s) will be used as the project folder token separator; otherwise, `Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR` will be used.
+* Changes
+  * Add test coverage for the above scenarios.
+  * Use File.join to join paths and files safely where appropriate.
+  * Update .gemspec gem description with more detail.
+
 ## ['3.5.0'] - 2022-10-04
 * Changes
   * Fix broken link to CHANGELOG.md in .gemspec file.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    branch-name (3.5.0)
+    branch-name (3.5.1)
       activesupport (~> 7.0, >= 7.0.4)
       colorize (~> 0.8.1)
       os (~> 1.1, >= 1.1.4)

--- a/branch-name.gemspec
+++ b/branch-name.gemspec
@@ -9,7 +9,13 @@ Gem::Specification.new do |spec|
   spec.email        = ['public.gma@gmail.com']
 
   spec.summary      = 'Generates a branch name based on a JIRA ticket/ticket number.'
-  spec.description  = 'Generates a branch name based on a JIRA ticket/ticket number.'
+  spec.description  = <<-EOF
+  branch-name is a gem that provides a command-line interface that allows you to accomplish several tasks, tasks I personally find myself having to carry out every time I work on a feature branch. I created this gem for myself; however, you are free to use it yourself, if any of these tasks fits into your personal routine:
+
+  1. Formulate a git feature branch name, given a jira ticket and jira ticket description. Why? Because I am constantly having to create git feature branch names that are based on jira ticket and jira ticket descriptions.
+  2. Optionally create a "project" based on the branch name (formulated in step 1 above). Why? Because I'm constantly having to create folders to manage files associated with the feature branches I am working on.
+  3. Optionally use and manage default options that determine the git feature branch name formulated, project greated, and default files associated with the project.Why? Because I routinely have to create files to support the feature I am working on and associate them with the feature I am working on. For example: scratch.rb to hold scratch code, snippets.rb to hold code to execute to perform redundant tasks, and readme.txt files to document things I need to remember.
+  EOF
   spec.homepage     = 'https://github.com/gangelo/branch-name'
   spec.license      = 'MIT'
 

--- a/lib/branch/name/normalizable.rb
+++ b/lib/branch/name/normalizable.rb
@@ -7,18 +7,28 @@ module Branch
     module Normalizable
       # The regex used to split ticket and ticket description tokens
       # to formulate a source control branch name.
-      BRANCH_NAME_REGEX = %r{[^/\w\x20]}
+      BRANCH_NAME_REGEX = %r{[^/\w\x20]|_}
 
       # The regex used to split ticket and ticket description tokens
       # to formulate a project folder based on the branch name formulated.
       PROJECT_FOLDER_REGEX = /[\W_]/
+
+      # Acceptable project folder token separators. If options[:separator]
+      # returns one of these acceptable values, it will be used; otherwise
+      # DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR will be used.
+      PROJECT_FOLDER_TOKEN_SEPARATORS = %W[- _]
+
+      # The default project folder token separator if options[:separator] is
+      # not an acceptable project folder token separator
+      # (i.e. PROJECT_FOLDER_TOKEN_SEPARATORS).
+      DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR = PROJECT_FOLDER_TOKEN_SEPARATORS.first
 
       def normalize_branch_name(ticket_description, ticket)
         formatted_branch_name = format_string_or_default
         formatted_branch_name = formatted_branch_name.gsub('%t', ticket || '')
         formatted_branch_name = formatted_branch_name.gsub('%d', ticket_description)
         formatted_branch_name = formatted_branch_name.gsub('%u', Etc.getlogin)
-        normalize_token formatted_branch_name, BRANCH_NAME_REGEX
+        normalize_token formatted_branch_name, BRANCH_NAME_REGEX, options[:separator]
       rescue Branch::Name::OptionError => e
         raise unless block_given?
 
@@ -29,7 +39,7 @@ module Branch
       # The location of the folder is not included; that is, the
       # folder returned is not fully qualified.
       def project_folder_name_from(normalized_branch_name)
-        normalize_token normalized_branch_name, PROJECT_FOLDER_REGEX
+        normalize_token normalized_branch_name, PROJECT_FOLDER_REGEX, project_folder_separator
       rescue Branch::Name::OptionError => e
         raise unless block_given?
 
@@ -52,14 +62,21 @@ module Branch
         format_string
       end
 
-      def normalize_token(token, regex)
+      def normalize_token(token, regex, separator)
         token = token.gsub(regex, ' ')
         token = token.strip
           .squeeze(' ')
-          .split.join(options[:separator])
-        token = token.squeeze(options[:separator])
+          .split.join(separator)
+        token = token.squeeze(separator)
         token = token.downcase if options[:downcase]
         token
+      end
+
+      def project_folder_separator
+        separator = options[:separator]
+        return options[:separator] if PROJECT_FOLDER_TOKEN_SEPARATORS.include? separator
+
+        DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR
       end
     end
   end

--- a/lib/branch/name/projectable.rb
+++ b/lib/branch/name/projectable.rb
@@ -2,11 +2,13 @@
 
 require 'fileutils'
 require_relative 'locatable'
+require_relative 'normalizable'
 
 module Branch
   module Name
     module Projectable
       include Locatable
+      include Normalizable
 
       def create_project!(branch_name)
         raise 'options[:project] is false' unless options[:project]
@@ -52,8 +54,9 @@ module Branch
       end
 
       def project_folder_for(branch_name)
+        branch_name = project_folder_name_from branch_name
         project_location = Time.new.strftime(options[:project_location])
-        "#{project_location}/#{branch_name}"
+        File.join(project_location, branch_name)
       end
     end
   end

--- a/lib/branch/name/version.rb
+++ b/lib/branch/name/version.rb
@@ -3,6 +3,6 @@
 module Branch
   module Name
     # branch-name version
-    VERSION = '3.5.0'
+    VERSION = '3.5.1'
   end
 end

--- a/spec/branch/name/normalizable_spec.rb
+++ b/spec/branch/name/normalizable_spec.rb
@@ -6,15 +6,24 @@ RSpec.shared_examples 'it formats the branch name properly' do
   end
 end
 
-RSpec.shared_examples 'the format_string is invalid' do
+RSpec.shared_examples 'it formats the folder name properly' do
+  it 'formats the folder name properly' do
+    expect(subject).to eq folder_name
+  end
+end
+
+RSpec.shared_examples 'the format_string (-x) is invalid' do
   it 'raises an error' do
     expected_error = /did not contain %t and %d format placeholders/
     expect { subject }.to raise_error(expected_error)
   end
 end
 
+PROJECT_FOLDER_TOKEN_SEPARATORS = Branch::Name::Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS
+DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR =  Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR
+
 RSpec.describe Branch::Name::Normalizable, type: :module do
-  subject(:normalizable) do
+  subject(:normalized_branch_name) do
     Class.new do
       include Branch::Name::Normalizable
 
@@ -47,7 +56,7 @@ RSpec.describe Branch::Name::Normalizable, type: :module do
   describe '#normalize_branch_name' do
     let(:branch_name) { 'TICKET_12345_Ticket_Description' }
 
-    context 'with downcase option' do
+    context 'with downcase (-d) option' do
       context 'when false' do
         let(:options) { default_options }
 
@@ -65,14 +74,40 @@ RSpec.describe Branch::Name::Normalizable, type: :module do
       end
     end
 
-    context 'with separator option' do
-      let(:options) { default_options.merge({ separator: 'x' }) }
-      let(:branch_name) { 'TICKETx12345xTicketxDescription' }
+    context 'with separator (-s) option' do
+      context 'when the separator is a dash (-)' do
+        let(:options) { default_options.merge({ separator: '-' }) }
+        let(:branch_name) { 'TICKET-NO-12345-Dash-and-Underscore-Ticket-Description' }
 
-      it_behaves_like 'it formats the branch name properly'
+        context 'when the ticket and description have both dashes (-) and underscores (_)' do
+          let(:ticket) { 'TICKET-NO_12345' }
+          let(:ticket_description) { 'Dash-and_Underscore Ticket_Description' }
+
+          it_behaves_like 'it formats the branch name properly'
+        end
+      end
+
+      context 'when the separator is an underscore (_)' do
+        let(:options) { default_options.merge({ separator: '_' }) }
+        let(:branch_name) { 'TICKET_NO_12345_Dash_and_Underscore_Ticket_Description' }
+
+        context 'when the ticket and description have both dashes (-) and underscores (_)' do
+          let(:ticket) { 'TICKET-NO_12345' }
+          let(:ticket_description) { 'Dash-and_Underscore Ticket_Description' }
+
+          it_behaves_like 'it formats the branch name properly'
+        end
+      end
+
+      context 'when the separator is a randon character (x)' do
+        let(:options) { default_options.merge({ separator: 'x' }) }
+        let(:branch_name) { 'TICKETx12345xTicketxDescription' }
+
+        it_behaves_like 'it formats the branch name properly'
+      end
     end
 
-    context 'with format_string option' do
+    context 'with format string (-x) option' do
       let(:options) { default_options.merge({ format_string: '%d %t' }) }
       let(:branch_name) { 'Ticket_Description_TICKET_12345' }
 
@@ -82,22 +117,71 @@ RSpec.describe Branch::Name::Normalizable, type: :module do
         let(:options) { default_options.merge({ format_string: '%d' }) }
         let(:branch_name) { 'Ticket_Description' }
 
-        it_behaves_like 'the format_string is invalid'
+        it_behaves_like 'the format_string (-x) is invalid'
       end
 
       context 'when the %d format placeholder is missing' do
         let(:options) { default_options.merge({ format_string: '%t' }) }
         let(:branch_name) { 'TICKET_12345' }
 
-        it_behaves_like 'the format_string is invalid'
+        it_behaves_like 'the format_string (-x) is invalid'
       end
 
       context 'when the %t and %d format placeholders are missing' do
         let(:options) { default_options.merge({ format_string: '12345' }) }
         let(:branch_name) { 'Ticket_Description_TICKET_12345' }
 
-        it_behaves_like 'the format_string is invalid'
+        it_behaves_like 'the format_string (-x) is invalid'
       end
+    end
+  end
+
+  describe '#project_folder_name_from' do
+    subject(:project_folder_name) do
+      Class.new do
+        include Branch::Name::Normalizable
+
+        attr_reader :options
+
+        def initialize(options)
+          @options = Thor::CoreExt::HashWithIndifferentAccess.new(options)
+        end
+
+        def current_command_chain
+          [:some_command]
+        end
+      end.new(options).project_folder_name_from(normalized_branch_name)
+    end
+
+    it do
+      # Sanity check; make sure we account for all separators in our
+      # below tests.
+      expect(PROJECT_FOLDER_TOKEN_SEPARATORS).to eq %W[- _]
+    end
+
+    context 'when the separator (-s) is included in Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS' do
+      context 'when an underscore (_)' do
+        let(:options) { default_options.merge({ separator: '_' }) }
+        let(:folder_name) { 'TICKET_12345_Ticket_Description' }
+
+        it_behaves_like 'it formats the folder name properly'
+      end
+
+      context 'when a dash ()' do
+        let(:options) { default_options.merge({ separator: '-' }) }
+        let(:folder_name) { 'TICKET-12345-Ticket-Description' }
+
+        it_behaves_like 'it formats the folder name properly'
+      end
+    end
+
+    context 'when the separator (-s) is NOT included in Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS' do
+      let(:options) { default_options.merge({ separator: DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR }) }
+      let(:folder_name) do
+        'TICKET#12345#Ticket#Description'.gsub('#', DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR)
+      end
+
+      it_behaves_like 'it formats the folder name properly'
     end
   end
 end

--- a/spec/branch/name/projectable_spec.rb
+++ b/spec/branch/name/projectable_spec.rb
@@ -1,0 +1,71 @@
+RSpec.shared_examples 'it formats the folder name properly' do
+  it 'formats the folder name properly' do
+    actual_folder_name = subject.project_folder_for branch_name
+    puts actual_folder_name
+    expect(actual_folder_name).to eq expected_folder_name
+  end
+end
+
+PROJECT_FOLDER_TOKEN_SEPARATORS = Branch::Name::Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS
+DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR =  Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR
+
+RSpec.describe Branch::Name::Projectable, type: :module do
+  subject(:projectable) do
+    Class.new do
+      include Branch::Name::Projectable
+
+      attr_reader :options
+
+      def initialize(options)
+        @options = Thor::CoreExt::HashWithIndifferentAccess.new(options)
+      end
+
+      def current_command_chain
+        [:some_command]
+      end
+    end.new(options)
+  end
+
+  let(:default_options) do
+    {
+      downcase: false,
+      separator: '_',
+      format_string: '%t %d',
+      project: false,
+      project_location: temp_directory.to_s,
+      project_files: %w[readme.txt scratch.rb snippets.rb]
+    }
+  end
+  let(:options) { default_options }
+  let(:expected_folder_name) do
+    File.join(temp_directory, branch_name)
+  end
+  let(:temp_directory) { Dir.tmpdir }
+
+  describe '#project_folder_for' do
+    context 'when the separator (-s) is included in Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS' do
+      context 'when an underscore (_)' do
+        let(:options) { default_options.merge({ separator: '_' }) }
+        let(:branch_name) { 'TICKET_12345_Ticket_Description' }
+
+        it_behaves_like 'it formats the folder name properly'
+      end
+
+      context 'when a dash ()' do
+        let(:options) { default_options.merge({ separator: '-' }) }
+        let(:branch_name) { 'TICKET-12345-Ticket-Description' }
+
+        it_behaves_like 'it formats the folder name properly'
+      end
+    end
+
+    context 'when the separator (-s) is NOT included in Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS' do
+      let(:options) { default_options.merge({ separator: DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR }) }
+      let(:branch_name) do
+        'TICKET#12345#Ticket#Description'.gsub('#', DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR)
+      end
+
+      it_behaves_like 'it formats the folder name properly'
+    end
+  end
+end


### PR DESCRIPTION
* Bug Fixes
  * Fix bug that failed to remove underscore (_) characters in ticket and ticket descriptions from
folder and branch name formulation.
  * Fix bug that allowed unacceptable project folder token separators in the project folder
name (-p option). The rule is now: for
`branch-name create`, if the `options[:separator]` option (-s) is included in
`Branch::Name::Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS`, `options[:separator]` (-s) will be used as the project folder token separator; otherwise,
`Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR` will be used.
* Changes
  * Add test coverage for the above scenarios.
  * Use File.join to join paths and files safely where appropriate.
  * Update .gemspec gem description with more detail.