### PR TITLE
Add interactive option to branch-name create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ['3.6.0'] - 2022-10-06
+* Changes
+  * Added a `-i` (interactive) option to `branch-name create`. When used in conjunction with the `-p` option (project creation), if the `-i` option is used, the user will be prompted to create the project. If the `-i` option is NOT used, the user will NOT be prompted when creating the project.
+  * Update the README.md file accordign to the aforementioned.
+
 ## ['3.5.1'] - 2022-10-05
 * Bug Fixes
   * Fix bug that failed to remove underscore (_) characters in ticket and ticket descriptions from folder and branch name formulation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    branch-name (3.5.1)
+    branch-name (3.6.0)
       activesupport (~> 7.0, >= 7.0.4)
       colorize (~> 0.8.1)
       os (~> 1.1, >= 1.1.4)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NOTE: You can manually change any of the options you wish. It is recommended tha
 
 The `create: project_location` option string also accepts any [`Time.strftime`](`https://apidock.com/ruby/Time/strftime`) format directives.
 
-The `create: format_string` option string can be used to position the *ticket* (`%t`) and *ticket description* (`%d`) within the branch name formulated. You can also include any other information you wish in the format string, for example: "`<username> %t %d`". However, non-word characters will be stripped (see `Branch::Name::Normalizable::NON_WORD_CHARS_REGEX` which equates to `/[\W_]/`)
+The `create: format_string` option string can be used to position the *ticket* (`%t`) and *ticket description* (`%d`) within the branch name formulated. You can also include any other information you wish in the format string, for example: "`<username> %t %d`". However, particular characters will be stripped to formulate the branch name (see `Branch::Name::Normalizable::BRANCH_NAME_REGEX` which equates to `%r{[^/\w\x20]|_}`).
 
 Any or all of these options can also be overwritten on the command-line. For more information:
 `$ branch-name config help init`
@@ -100,13 +100,16 @@ create:
   - readme.txt
   - scratch.rb
   - snippets.rb
+  interactive: true
   ```
 
-This example formulates feature a branch named *lg-12345-pay-down-tech-debt-on-user-model* by converting the ticket and ticket description to lowercase (`-d`) and delimiting the feature branch name tokens with a "-" character (`-s -`). The `-p` option instructs `branch-name create` to create the project folder */Users/<username>/feature-branches/2022/lg-12345-pay-down-tech-debt-on-user-model*. The aforementioned project folder will also contain the following files: readme.txt, scratch.rb and snippets.rb. In addition to this, `branch-name create` will also copy the feature brach name to the clipboard for you (macOS and Windows currently supported). This is convenient when you need to create a feature branch in github, or from the command-line.
+This example formulates feature a branch named *lg-12345-pay-down-tech-debt-on-user-model* by converting the ticket and ticket description to lowercase (`-d`) and delimiting the feature branch name tokens with a "-" character (`-s -`). The `-p` option instructs `branch-name create` to create the project folder */Users/<username>/feature-branches/2022/lg-12345-pay-down-tech-debt-on-user-model*, and finally, the `-i false` option instructs `branch-name` to *not* prompt the user when creating projects. The aforementioned project folder will also contain the following files: readme.txt, scratch.rb and snippets.rb. In addition to this, `branch-name create` will also copy the feature brach name to the clipboard for you (macOS and Windows currently supported). This is convenient when you need to create a feature branch in github, or from the command-line.
 
 ```shell
-$ branch-name create -p -d -s - "Pay down tech debt on User model" LG-12345
+$ branch-name create -i false -p -d -s - "Pay down tech debt on User model" LG-12345
 ```
+
+NOTE: When creating projects, `branch-name` will prompt you if the `interactive` option is true (`-i`).
 
 This example simply formulates feature a branch named *Add_create_and_destroy_session_controller_actions* and copies it to the clipboard.
 
@@ -133,7 +136,7 @@ $ branch-name create "<username>/UX-54321 Remove debug code"
 ...
 ```
 
-NOTE: Project folders created (`--project/-p`) will replace any forward-slash with the `create: :separator` option value.
+NOTE: Project folders that are formulated (`branch-name create [-p|--project] ...`), will have any tokens comprising the project folder name delimited according to the following rules: if the `options[:separator]` option (-s) is included in `Branch::Name::Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS`, `options[:separator]` (-s) will be used as the project folder token delimiter; otherwise, `Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR` will be used.
 
 ## Development
 

--- a/lib/branch/name/cli.rb
+++ b/lib/branch/name/cli.rb
@@ -44,42 +44,46 @@ module Branch
 
         SYNOPSIS
         \x5
-        branch-name create [-l|-f|-d|-s|-p|-x] DESCRIPTION [TICKET]
+        branch-name create [-i|-l|-f|-d|-s|-p|-x] DESCRIPTION [TICKET]
 
         \x5
         The following options are available:
 
         \x5 NOTE: Default option values will be overidden if .branch-name config files
-        are present. Run `branch-name config info` to determine what config files
-        are present.
+          are present. Run `branch-name config info` to determine what config files
+          are present.
 
         \x5 -d: Forces the branch name to lower case.
-                The default is: #{DEFAULT_BRANCH_NAME_OPTIONS['create']['downcase']}.
-
-        \x5\x5 -s SEPARATOR: Indicates the SEPARATOR that will be used to delimit tokens in the branch name.
-               The default SEPARATOR is: '#{DEFAULT_BRANCH_NAME_OPTIONS['create']['separator']}'.
-
-        \x5\x5 -p: Indicates that a project should be created.
-               The default is: #{DEFAULT_BRANCH_NAME_OPTIONS['create']['project']}.
+          The default is: #{DEFAULT_BRANCH_NAME_OPTIONS['create']['downcase']}.
 
         \x5 -f: Used with the -p option. If -f is specified, project files
-            will be created in the PROJECT_LOCATION specified by the -l option.
-            The default is: #{DEFAULT_BRANCH_NAME_OPTIONS['create']['project_files']}.
+          will be created in the PROJECT_LOCATION specified by the -l option.
+          The default is: #{DEFAULT_BRANCH_NAME_OPTIONS['create']['project_files']}.
+
+        \x5 -i: Interactive. Used with the -p option. If -i is specified, you will
+          be prompted when creating project folders. If -i is not specified, you will
+          NOT be prompted when creating project folders.
 
         \x5\x5 -l PROJECT_LOCATION: Indicates where the project should be created.
-            A "project" is a folder that is created in the PROJECT_LOCATION specified,
-            whose name is equivalent to the branch name that is formulated.
-            The default is: "#{Locatable.project_folder(options: options)}".
+          A "project" is a folder that is created in the PROJECT_LOCATION specified,
+          whose name is equivalent to the branch name that is formulated.
+          The default is: "#{Locatable.project_folder(options: options)}".
+
+        \x5\x5 -p: Indicates that a project should be created.
+          The default is: #{DEFAULT_BRANCH_NAME_OPTIONS['create']['project']}.
+
+        \x5\x5 -s SEPARATOR: Indicates the SEPARATOR that will be used to delimit tokens in the branch name.
+          The default SEPARATOR is: '#{DEFAULT_BRANCH_NAME_OPTIONS['create']['separator']}'.
 
         \x5 -x FORMAT_STRING: This is a string that determines the format of the branch name
-            that is formulated. The following is a list of required placeholders you must put
-            in your format string to format the branch name: [%t, %d].
-            \x5Where %t will be replaced by the ticket.
-            \x5Where %d will be replaced by the ticket description.
-            \x5The following is a list of optional placeholders you may put
-            in your format string to format the branch name: [%u].
-            \x5Where %u will be replaced with your username (`Etc.getlogin`, https://rubygems.org/gems/etc).
-            \x5The default format string is: "#{DEFAULT_BRANCH_NAME_OPTIONS['create']['format_string']}".
+          that is formulated. The following is a list of required placeholders you must put
+          in your format string to format the branch name: [%t, %d].
+          \x5Where %t will be replaced by the ticket.
+          \x5Where %d will be replaced by the ticket description.
+          \x5The following is a list of optional placeholders you may put
+          in your format string to format the branch name: [%u].
+          \x5Where %u will be replaced with your username (`Etc.getlogin`, https://rubygems.org/gems/etc).
+          \x5The default format string is: "#{DEFAULT_BRANCH_NAME_OPTIONS['create']['format_string']}".
       LONG_DESC
       method_option :downcase, type: :boolean, aliases: '-d'
       method_option :separator, type: :string, aliases: '-s'
@@ -87,6 +91,7 @@ module Branch
       method_option :project, type: :boolean, aliases: '-p'
       method_option :project_location, type: :string, aliases: '-l'
       method_option :project_files, type: :array, aliases: '-f'
+      method_option :interactive, type: :boolean, aliases: '-i'
 
       def create(ticket_description, ticket = nil)
         if ticket_description.blank?
@@ -108,11 +113,13 @@ module Branch
             say_error error.message
             exit 1
           end
-          project_folder = project_folder_for branch_name
-          unless yes? "Create project for branch \"#{branch_name}\" " \
-                      "in folder \"#{project_folder}\" (y/n)?", :cyan
-            say 'Aborted.', ABORTED
-            return
+          if options[:interactive]
+            project_folder = project_folder_for branch_name
+            unless yes? "Create project for branch \"#{branch_name}\" " \
+                        "in folder \"#{project_folder}\" (y/n)?", :cyan
+              say 'Aborted.', ABORTED
+              return
+            end
           end
 
           say "Project folder name: \"#{project_folder_name}\"", :cyan

--- a/lib/branch/name/configurable.rb
+++ b/lib/branch/name/configurable.rb
@@ -22,7 +22,8 @@ module Branch
           'format_string' => '%t %d',
           'project' => false,
           'project_location' => "#{Locatable.project_folder}/branch-name/projects/%Y/%m (%B)",
-          'project_files' => %w[readme.txt scratch.rb snippets.rb]
+          'project_files' => %w[readme.txt scratch.rb snippets.rb],
+          'interactive' => true
         }
       }.freeze
       # rubocop:enable Style/StringHashKeys

--- a/lib/branch/name/normalizable.rb
+++ b/lib/branch/name/normalizable.rb
@@ -16,7 +16,7 @@ module Branch
       # Acceptable project folder token separators. If options[:separator]
       # returns one of these acceptable values, it will be used; otherwise
       # DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR will be used.
-      PROJECT_FOLDER_TOKEN_SEPARATORS = %W[- _]
+      PROJECT_FOLDER_TOKEN_SEPARATORS = %w[- _].freeze
 
       # The default project folder token separator if options[:separator] is
       # not an acceptable project folder token separator

--- a/lib/branch/name/version.rb
+++ b/lib/branch/name/version.rb
@@ -3,6 +3,6 @@
 module Branch
   module Name
     # branch-name version
-    VERSION = '3.5.1'
+    VERSION = '3.6.0'
   end
 end

--- a/spec/branch/name/normalizable_spec.rb
+++ b/spec/branch/name/normalizable_spec.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples 'the format_string (-x) is invalid' do
 end
 
 PROJECT_FOLDER_TOKEN_SEPARATORS = Branch::Name::Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS
-DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR =  Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR
+DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR = Branch::Name::Normalizable::DEFAULT_PROJECT_FOLDER_TOKEN_SEPARATOR
 
 RSpec.describe Branch::Name::Normalizable, type: :module do
   subject(:normalized_branch_name) do
@@ -156,7 +156,7 @@ RSpec.describe Branch::Name::Normalizable, type: :module do
     it do
       # Sanity check; make sure we account for all separators in our
       # below tests.
-      expect(PROJECT_FOLDER_TOKEN_SEPARATORS).to eq %W[- _]
+      expect(PROJECT_FOLDER_TOKEN_SEPARATORS).to eq %w[- _]
     end
 
     context 'when the separator (-s) is included in Normalizable::PROJECT_FOLDER_TOKEN_SEPARATORS' do

--- a/spec/branch/name/projectable_spec.rb
+++ b/spec/branch/name/projectable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'it formats the folder name properly' do
   it 'formats the folder name properly' do
     actual_folder_name = subject.project_folder_for branch_name


### PR DESCRIPTION
- Added a `-i` (interactive) option to `branch-name create`. When used in conjunction
with the `-p` option (project creation), if the
`-i` option is used, the user will be prompted to
create the project. If the `-i` option is NOT used, the user will NOT be prompted when creating the project.
- Update the README.md file accordign to the aforementioned.